### PR TITLE
Fix design issues due to double nesting, cleanup, original send icon

### DIFF
--- a/Spam script
+++ b/Spam script
@@ -2,13 +2,11 @@
 
     function general(){
         if(document.getElementsByClassName("app-wrapper-main")[0] != null){
-            var item = document.createElement("div");							  // Create button
-            item.innerHTML = "<img src='http://k30.kn3.net/9CE61B28D.png' style='width:24px;height:24px;cursor:pointer' id='spam'>";
             var item2 = document.getElementsByClassName("pane-header pane-list-header")[0];
-            item2.insertBefore(item, item2.childNodes[1]);
             var panel = document.getElementsByClassName("chatlist-panel pane pane-one")[0];
-            element = document.createElement("div");							  // Create text and reps inputs
-            element.innerHTML = "<header class='pane-header pane-list-header'><input type='text' id='mensaje' placeholder='Message' style='margin-right:10px' size='30'><input type='number' min='1' id='repeticiones' style='width:50px;padding-left:5px;margin-right:5px'>Times </header>";
+            element = item2.cloneNode(true);							  // Create text and reps inputs
+			element.style.zIndex = '100';
+            element.innerHTML = "<input type='text' id='mensaje' placeholder='Message' style='margin-right:10px' size='30'><input type='number' min='1' id='repeticiones' style='width:50px;padding-left:5px;margin-right:5px'>Times<div id='spam' data-icon=\"send\" class=\"img icon icon-send\" style='margin-left: 5px;cursor:pointer;'><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" width=\"24\" height=\"24\"><path opacity=\".4\" d=\"M1.101 21.757L23.8 12.028 1.101 2.3l.011 7.912 13.623 1.816-13.623 1.817-.011 7.912z\"></path></svg></div>";
             panel.insertBefore(element, panel.childNodes[1]);					  // Insert everything we have created
             document.getElementById("spam").addEventListener("click", spam);     // Assign a function to the botton
             clearInterval(timer);
@@ -24,7 +22,7 @@
         });
         input.innerHTML = message;								// Get text to spam
         input.dispatchEvent(evt);								// Fire the event (inserts text) in the input field.
-        document.querySelector(".icon-send").click(); 			// Press send button
+        document.querySelector(".compose-btn-send > .icon-send").click(); 			// Press send button
     }
 
     function spam(){


### PR DESCRIPTION
This is how it looks using the Stylish extension and this theme: https://userstyles.org/styles/142096/dark-whatsapp-theme-by-mew

![image](https://user-images.githubusercontent.com/8733998/27808558-ecf09f50-6048-11e7-9b9c-71fdfbf9a5bc.png)

i thought about changing the inputs to look like the search field, but that messed up with device width (for now)